### PR TITLE
Fixing 7.3 sound issues - SOUNDKIT changeover

### DIFF
--- a/Classes/ButtonBase.lua
+++ b/Classes/ButtonBase.lua
@@ -20,7 +20,7 @@ along with Sushi. If not, see <http://www.gnu.org/licenses/>.
 local TipOwner = SushiTipOwner
 local Button = MakeSushi(1, 'Button', 'ButtonBase', nil, nil, TipOwner)
 if Button then
-	Button.sound = 'igMainMenuOptionCheckBoxOn'
+	Button.sound = SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON
 else
 	return
 end

--- a/Classes/CheckButton.lua
+++ b/Classes/CheckButton.lua
@@ -49,11 +49,11 @@ end
 function Check:OnClick ()
 	local checked = self:GetChecked()
 	if checked then
-		PlaySound('igMainMenuOptionCheckBoxOn')
-	else
-		PlaySound('igMainMenuOptionCheckBoxOff')
-	end
-	
+	  PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
+  else
+	  PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
+  end
+
 	self:FireCall('OnClick', checked)
 	self:FireCall('OnInput', checked)
 	self:FireCall('OnUpdate')

--- a/Classes/ColorPicker.lua
+++ b/Classes/ColorPicker.lua
@@ -31,18 +31,18 @@ function Color:OnCreate ()
 	Border:SetTexture('Interface\\ChatFrame\\ChatFrameColorSwatch')
 	Border:SetWidth(23) Border:SetHeight(23)
 	Border:SetPoint('Center')
-	
+
 	local Color = self:CreateTexture(nil, 'OVERLAY')
 	Color:SetTexture('Interface\\ChatFrame\\ChatFrameColorSwatch')
 	Color:SetWidth(19) Color:SetHeight(19)
 	Color:SetPoint('Center')
 	self.Color = Color
-	
+
 	local Glow = self:CreateTexture()
 	Glow:SetTexture('Interface\\Buttons\\UI-CheckBox-Highlight')
 	Glow:SetWidth(21) Glow:SetHeight(23)
 	Glow:SetPoint('Center')
-	
+
 	self:SetHighlightTexture(Glow)
 	self:SetDisabledTexture(nil)
 	self:SetCheckedTexture(nil)
@@ -80,9 +80,9 @@ function Color:OnClick ()
 	ColorPickerFrame.cancelFunc = function()
 		self:SaveColor(r, g, b, a)
 	end
-	
+
 	ShowUIPanel(ColorPickerFrame)
-	PlaySound('igMainMenuOptionCheckBoxOn')
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
 end
 
 

--- a/Classes/DropdownFrame.lua
+++ b/Classes/DropdownFrame.lua
@@ -40,7 +40,7 @@ function Drop:OnAcquire()
 	self:SetFrameStrata('FULLSCREEN_DIALOG')
 	self:SetCall('UpdateChildren', function()
 		self.width = 0
-		
+
 		local lines = get(self.lines, self)
 		if lines then
 			for i, line in ipairs(lines) do
@@ -114,14 +114,14 @@ end
 function Drop:Toggle(...)
 	local n = select('#', ...)
 	local anchor = select(n < 4 and 1 or 2, ...)
-	
+
 	if anchor ~= self.target then
 		self:Display(...)
 	else
 		CloseDropDownMenus()
 	end
 
-	PlaySound('igMainMenuOptionCheckBoxOn')
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
 end
 
 function Drop:Display(...)

--- a/Classes/TabButtons.lua
+++ b/Classes/TabButtons.lua
@@ -71,7 +71,7 @@ end
 
 --[[ Proprieties ]]--
 
-Tab.sound = 'igCharacterInfoTab'
+Tab.sound = SOUNDKIT.CHARACTER_INFO_TAB
 Tab.SetLabel = Tab.SetText
 Tab.GetLabel = Tab.GetText
 Tab.SetValue = Tab.SetSelected

--- a/Classes/TextureDropdown.lua
+++ b/Classes/TextureDropdown.lua
@@ -45,14 +45,14 @@ BG:SetBackdrop({
 DropList:SetContent(function()
 	local self = DropList.parent
 	local width, height = self:GetButtonSize()
-	
+
 	for value, image, tip in self:IterateLines() do
 		local button = DropList:Create('TextureButton')
 		button:SetCall('OnUpdate', nil)
 		button:SetSize(width, height)
 		button:SetTexture(image)
 		button:SetTip(tip)
-		
+
 		button:SetCall('OnInput', function()
 			self:FireCall('OnLineSelected', value)
 			self:FireCall('OnSelection', value)
@@ -69,54 +69,54 @@ end)
 function TexDrop:OnCreate()
 	local name = self:GetName()
 	Dropdown.OnCreate (self)
-	
+
 	-- Left
 	local TopLeft = _G[name .. 'Left']
 	TopLeft:SetTexCoord(0, 0.1953125, 0, 0.4)
 	TopLeft:SetPoint('TOPLEFT', 0, 13)
 	TopLeft:SetHeight(19.2)
-	
+
 	local BotLeft = self:CreateTexture()
 	BotLeft:SetTexture('Interface\\Glues\\CharacterCreate\\CharacterCreate-LabelFrame')
 	BotLeft:SetHeight(15) BotLeft:SetWidth(25)
 	BotLeft:SetTexCoord(0, 0.1953125, 0.5, 1)
 	BotLeft:SetPoint('BOTTOMLEFT')
-	
+
 	local Left = self:CreateTexture()
 	Left:SetTexture('Interface\\Glues\\CharacterCreate\\CharacterCreate-LabelFrame')
 	Left:SetTexCoord(0, 0.1953125, 0.5, 0.5)
 	Left:SetPoint('TOP', TopLeft, 'BOTTOM')
 	Left:SetPoint('BOTTOM', BotLeft, 'TOP')
 	Left:SetWidth(25)
-	
+
 	-- Right
 	local TopRight = _G[name .. 'Right']
 	TopRight:SetTexCoord(0.8046875, 1, 0, 0.4)
 	TopRight:SetPoint('TOPRIGHT', 0, 13)
 	TopRight:SetHeight(19.2)
-	
+
 	local BotRight = self:CreateLabelTexture()
 	BotRight:SetHeight(15) BotRight:SetWidth(25)
 	BotRight:SetTexCoord(0.8046875, 1, 0.5, 1)
 	BotRight:SetPoint('BOTTOMRIGHT')
-	
+
 	local Right = self:CreateLabelTexture()
 	Right:SetTexCoord(0.8046875, 1, 0.5, 0.5)
 	Right:SetPoint('TOP', TopRight, 'BOTTOM')
 	Right:SetPoint('BOTTOM', BotRight, 'TOP')
 	Right:SetWidth(25)
-	
+
 	-- Middle
 	local TopMiddle = _G[name .. 'Middle']
 	TopMiddle:SetTexCoord(0.1953125, 0.8046875, 0, 0.4)
 	TopMiddle:SetHeight(19.2)
-	
+
 	local BotMiddle = self:CreateLabelTexture()
 	BotMiddle:SetTexCoord(0.1953125, 0.8046875, 0.5, 1)
 	BotMiddle:SetPoint('RIGHT', BotRight, 'LEFT')
 	BotMiddle:SetPoint('LEFT', BotLeft, 'RIGHT')
 	BotMiddle:SetHeight(15)
-	
+
 	local Middle = self:CreateTexture()
 	Middle:SetTexture('Interface\\FrameGeneral\\UI-Background-Marble')
 	Middle:SetPoint('BOTTOM', BotMiddle, 'TOP', 0, -3)
@@ -125,12 +125,12 @@ function TexDrop:OnCreate()
 	Middle:SetPoint('LEFT', Left, 'RIGHT', -2, 0)
 	Middle:SetHorizTile(true)
 	Middle:SetVertTile(true)
-	
+
 	-- Ohter
 	self.Button:ClearAllPoints()
 	self.Button:SetPoint('TOPRIGHT', -16, 0)
 	self.Button:SetScript('OnClick', function() self:OnClick() end)
-	
+
 	self.Display = SushiTextureButton(self)
 	self.Display:SetPoint('BOTTOMRIGHT', Middle, -15, 5)
 	self.Display:SetPoint('TOPLEFT', Middle, 15, -5)
@@ -153,12 +153,12 @@ end
 --[[ Other ]]--
 
 function TexDrop:OnClick()
-	PlaySound('igMainMenuOptionCheckBoxOn')
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
 	DropList:ClearAllPoints()
 
 	if not DropList:IsShown() or DropList.parent ~= self then
 		CloseDropDownMenus()
-		
+
 		DropList.parent = self
 		DropList:SetWidth(min(self:NumLines(), 3) * (self:GetButtonSize() + 20))
 		DropList:SetPoint('TOPLEFT', self, 'BOTTOMLEFT', 16, -4)


### PR DESCRIPTION
Fixes for the SOUNDKIT change in 7.3. Note that some whitespace stuff got butchered a bit; autoformat went a bit nuts in Atom and made some changes. I need to run to raid, but should be easy to revert everything back except the string changes. Sorry for the hassle. 

I think I caught all of the potential places that you'll run into issues; the 5 that Bagnon relies on plus a character tab sound. I couldn't figure out how to exercise that functionality on short notice, so should be tested by someone who knows better.