### PR TITLE
fix: invalid tab sound property

### DIFF
--- a/Classes/TabButtons.lua
+++ b/Classes/TabButtons.lua
@@ -71,7 +71,7 @@ end
 
 --[[ Proprieties ]]--
 
-Tab.sound = 'igCharacterInfoTab'
+Tab.sound = SOUNDKIT.IG_CHARACTER_INFO_TAB
 Tab.SetLabel = Tab.SetText
 Tab.GetLabel = Tab.GetText
 Tab.SetValue = Tab.SetSelected


### PR DESCRIPTION
- Clicking a tab currently results in an error being thrown since `igCharacterInfoTab` isn't a valid sound effect name.

_verified that `SOUNDKIT.IG_CHARACTER_INFO_TAB` exists in both Retail and Classic WoW_