### PR TITLE
Fix color picker for Classic addons

### DIFF
--- a/classes/checks/Color.lua
+++ b/classes/checks/Color.lua
@@ -20,7 +20,6 @@ along with Sushi. If not, see <http://www.gnu.org/licenses/>.
 local Color = LibStub('Sushi-3.2').TextedClickable:NewSushi('ColorPicker', 2, 'Button')
 if not Color then return end
 
-ColorPickerFrame.SetupColorPickerAndShow = ColorPickerFrame.SetupColorPickerAndShow or function(_,...) OpenColorPicker(...) end
 ColorPickerFrame:HookScript('OnHide', function() 
 	if Color.Active and Color.Active:GetButtonState() == 'PUSHED' then
 		Color.Active:SetButtonState('NORMAL')
@@ -89,12 +88,29 @@ function Color:OnClick()
 	end
 
 	Color.Active = self
-	ColorPickerFrame:SetupColorPickerAndShow {
-		cancelFunc = function() set(color) end,
-		swatchFunc = update, opacityFunc = update,
-		hasOpacity = self:HasAlpha(), opacity = color.a,
-		r = color.r, g = color.g, b = color.b,
-	}
+    if ColorPickerFrame.SetupColorPickerAndShow then -- 10.2.5
+        ColorPickerFrame:SetupColorPickerAndShow({
+            cancelFunc = function() set(color) end,
+            swatchFunc = update,
+            opacityFunc = update,
+            hasOpacity = self:HasAlpha(),
+            opacity = color.a,
+            r = color.r,
+            g = color.g,
+            b = color.b
+        })
+    else -- Classic
+        OpenColorPicker({
+            cancelFunc = function() set(color) end,
+            swatchFunc = update,
+            opacityFunc = update,
+            hasOpacity = self:HasAlpha(),
+            opacity = color.a,
+            r = color.r,
+            g = color.g,
+            b = color.b
+        })
+    end
 
 	self:SetButtonState('PUSHED', true)
 	PlaySound(self.Sound)


### PR DESCRIPTION
The latest Bagnon update 10.2.18 broke the color picker functionality for some addons in Classic
such as WeakAuras. This is a result of ColorPickerFrame.SetupColorPickerAndShow being assigned in the Sushi library as the presence of this function is used by other addons to determine the game version.

This PR proposes a fix for this issue that should work with both versions of the game (I've only tested the Classic version however).

Related issues:
https://github.com/Jaliborc/Bagnon/issues/1874
https://github.com/Jaliborc/Bagnon/issues/1875