### PR TITLE
Update Options for Cata and The War Within

### DIFF
--- a/classes/drops/Dropdown.lua
+++ b/classes/drops/Dropdown.lua
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Sushi. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
-local Drop, old = LibStub('Sushi-3.2').Group:NewSushi('Dropdown', 2, 'Frame')
+local Drop, old = LibStub('Sushi-3.2').Group:NewSushi('Dropdown', 3, 'Frame')
 if not Drop then return end
 
 
@@ -127,7 +127,15 @@ function Drop:Add(object, ...)
 end
 
 function Drop:IsMouseInteracting()
-	return DoesAncestryInclude(self:GetParent(), GetMouseFocus())
+	local mouseFoci = GetMouseFoci and GetMouseFoci() or {GetMouseFocus()}
+
+	for _, mouseFocus in ipairs(mouseFoci) do
+		if DoesAncestryInclude(self:GetParent(), mouseFocus) then
+			return true
+		end
+	end
+
+	return false
 end
 
 

--- a/classes/groups/Group.lua
+++ b/classes/groups/Group.lua
@@ -154,8 +154,8 @@ function Group:Layout()
 			top, left = self:Orient(top, left)
 
 			if self.limit and (x + width) > self.limit then
-	 			breakLine()
-	 		end
+				breakLine()
+			end
 
 			local a,b = self:Orient(x + left, y + top)
 			child:ClearAllPoints()

--- a/classes/groups/Options.lua
+++ b/classes/groups/Options.lua
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Sushi. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
-local Group = LibStub('Sushi-3.2').Group:NewSushi('OptionsGroup', 2, 'Frame')
+local Group = LibStub('Sushi-3.2').Group:NewSushi('OptionsGroup', 3, 'Frame')
 if not Group then return end
 
 

--- a/classes/groups/Options.lua
+++ b/classes/groups/Options.lua
@@ -42,7 +42,6 @@ function Group:New(category, subcategory)
 
 	local group = self:Super(Group):New(dock)
 	group.name, group.title = dock.name, dock.name
-	group.category = dock.parent or dock.name
 
 	group:SetPoint('BOTTOMRIGHT', -4, 5)
 	group:SetPoint('TOPLEFT', 4, -11)
@@ -63,16 +62,12 @@ function Group:New(category, subcategory)
 	dock.OnRefresh = function() group:FireCalls('OnRefresh') end
 
 	if subcategory then
-		local parent = Settings.GetCategory(dock.parent)
-		local child = Settings.RegisterCanvasLayoutSubcategory(parent, dock, dock.name)
-		-- BUG: SettingsCategoryMixin:Init(name) sets category.ID to a number
-		child.ID = dock.name
+		local parent = Settings.GetCategory(category.category:GetID())
+		group.category = Settings.RegisterCanvasLayoutSubcategory(parent, dock, dock.name)
 	else
-		local parent = Settings.RegisterCanvasLayoutCategory(dock, dock.name)
-		-- BUG: SettingsCategoryMixin:Init(name) sets category.ID to a number
-		parent.ID = dock.name
+		group.category = Settings.RegisterCanvasLayoutCategory(dock, dock.name)
 
-		Settings.RegisterAddOnCategory(parent)
+		Settings.RegisterAddOnCategory(group.category)
 	end
 
 	dock:Hide()
@@ -84,7 +79,9 @@ end
 --[[ API ]]--
 
 function Group:Open()
-	Settings.OpenToCategory(self.category)
+	-- cannot open to a subcategory
+	local category = self.category:GetParentCategory() or self.category
+	Settings.OpenToCategory(category:GetID())
 end
 
 function Group:SetTitle(title)


### PR DESCRIPTION
I haven't tested this on Classic, but AFAIK it should be valid there as well.

Implementation Notes:

- ~~[SettingsCategoryMixin:Init](https://github.com/Gethe/wow-ui-source/blob/b4c9176d321abca2b959444c0379c5858a02c3af/Interface/AddOns/Blizzard_Settings_Shared/Blizzard_Category.lua#L8) sets the category ID to an auto-incremented number, but categories are queried by name. This seems to be a Blizzard bug and is being accounted for~~
- `OnCancel` does not seem to be called anywhere by Blizz code, but it is still present on [SettingsCanvasMixin](https://github.com/Gethe/wow-ui-source/blob/b4c9176d321abca2b959444c0379c5858a02c3af/Interface/AddOns/Blizzard_Settings_Shared/Blizzard_SettingsCanvas.lua). I kept it just in case.

